### PR TITLE
Create a helper to format currency values

### DIFF
--- a/app/helpers/format-currency.js
+++ b/app/helpers/format-currency.js
@@ -1,0 +1,18 @@
+import { helper } from '@ember/component/helper';
+
+export function formatCurrency(value, namedArgs) {
+  if (isNaN(value)) {
+    value = 0;
+  }
+
+  let sign = namedArgs.sign === undefined ? '$' : namedArgs.sign;
+  let remainder = parseInt((value * 100) % 100, 10);
+  let intPart = parseInt(value, 10);
+
+  if (remainder.toString().length === 1) {
+    remainder = '0' + remainder;
+  }
+  return `${sign} ${intPart}.${remainder}`;
+}
+
+export default helper(formatCurrency);

--- a/app/templates/orders.hbs
+++ b/app/templates/orders.hbs
@@ -30,7 +30,7 @@
           <td>{{order.creationDate}}</td>
           <td>{{order.items.length}}</td>
           <td>{{order.totalItems}}</td>
-          <td>{{money order.totalPrice}}</td>
+          <td>{{format-currency order.totalPrice}}</td>
           <td><button {{action "remove" order}} class="button tiny radius alert"> Delete </button></td>
         </tr>
       {{/each}}

--- a/app/templates/products.hbs
+++ b/app/templates/products.hbs
@@ -26,7 +26,7 @@
           <td>{{#link-to "products.edit" product}} {{product.id}} {{/link-to}}</td>
           <td>{{product.name}}</td>
           <td>{{product.description}}</td>
-          <td>{{product.price}}</td>
+          <td>{{format-currency product.price}}</td>
           <td><button {{action "remove" product}} class="button tiny radius alert"> Delete </button></td>
         </tr>
       {{/each}}

--- a/tests/integration/helpers/format-currency-test.js
+++ b/tests/integration/helpers/format-currency-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | format-currency', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{format-currency inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});


### PR DESCRIPTION
Use Ember CLI to create a new helper function

`ember generate helper format-currency`

This helper shows float values like _**12.34**_ formatted as currency _**$ 12.34**_